### PR TITLE
Adding 'tmo ls need' and 'tmo ls have' to commandlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This addon works by checking your bags for stacks of consumables that are not to
 
 ```
 /tmo add <itemlink> <amount> - how much of the item you want to carry. You get an item link via shift-click.
-/tmo ls - see the buy list
+/tmo ls - see the full buy list
+/tmo ls need - see the items needed off the buy list
+/tmo ls have - see the items you have from the buy list
 /tmo del <itemlink> - remove 1 item from the list. You get an item link via shift-click.
 /tmo reset - reset the buy list
 ```

--- a/TopMeOff.toc
+++ b/TopMeOff.toc
@@ -2,7 +2,7 @@
 ## Title: TopMeOff
 ## Notes: Automatically tops off reagent stacks when you talk to a reagent vendor.
 ## Author: melba
-## Version: 2
+## Version: 2.1
 ## Dependencies:
 ## SavedVariablesPerCharacter: reagentsWanted
 TopMeOff.lua


### PR DESCRIPTION
I'm using TMO like a shopping list that includes items that can be purchased from vendors and others that can not be.  The list is long.  It'd be nice pre-raid to say `/tmo ls need` to get a shopping/vendor-run-around listing